### PR TITLE
Pin node and npm engines to compatible major versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/jsonwebtoken": "^9.0.6",
         "ajv": "^8.16.0",
         "ajv-formats": "^3.0.1",
         "axios": "^1.7.4",
@@ -21,6 +20,7 @@
         "@eslint/js": "^9.17.0",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.14",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^22.10.3",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "@typescript-eslint/parser": "^8.19.0",
@@ -1616,6 +1616,7 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.6.tgz",
       "integrity": "sha512-/5hndP5dCjloafCXns6SZyESp3Ldq7YjH3zwzwczYnjxIT0Fqzk5ROSYVGfFyczIue7IUEj8hkvLbPoLQ18vQw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1630,6 +1631,7 @@
       "version": "22.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.3.tgz",
       "integrity": "sha512-DifAyw4BkrufCILvD3ucnuN8eydUfc/C1GlyrnI+LK6543w5/L3VeVgf05o3B4fqSXP1dKYLOZsKfutpxPzZrw==",
+      "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -5935,7 +5937,8 @@
     "node_modules/undici-types": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "npm": "10.x"
   },
   "dependencies": {
-    "@types/jsonwebtoken": "^9.0.6",
     "ajv": "^8.16.0",
     "ajv-formats": "^3.0.1",
     "axios": "^1.7.4",
@@ -32,6 +31,7 @@
     "@eslint/js": "^9.17.0",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
+    "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^22.10.3",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[DCMAW-XXXX] PR Title` -->

### What changed
- Pin `node` and `npm` engines to compatible major versions in the `package.json`
- Move `@types/jsonwebtoken` to `devDependencies`

### Why did it change
- To ensure `node` versions in the `.nvmrc` file and `package.json` match

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations
<!-- Add any other consideration if needed -->