### PR TITLE
DCMAW-10940: update credential tests

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -99,7 +99,6 @@ describe("credential issuer tests", () => {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
         error: "invalid_credential_request",
-        error_description: "Access token failed to validate",
       });
     }
   });
@@ -132,7 +131,6 @@ describe("credential issuer tests", () => {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
         error: "invalid_credential_request",
-        error_description: "Access token failed to validate",
       });
     }
   });
@@ -163,7 +161,6 @@ describe("credential issuer tests", () => {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
         error: "invalid_proof",
-        error_description: "Proof failed to validate",
       });
     }
   });
@@ -195,7 +192,6 @@ describe("credential issuer tests", () => {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
         error: "invalid_proof",
-        error_description: "Proof failed to validate",
       });
     }
   });
@@ -264,7 +260,6 @@ describe("credential issuer tests", () => {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
         error: "invalid_credential_request",
-        error_description: "Credential offer not found",
       });
     }
   });


### PR DESCRIPTION
Related PR: https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/88

## Proposed changes
### What changed
Credential tests:
- Update the credential offer not found test to expect a 400 status code instead of 404

<img width="1174" alt="Screenshot 2025-01-10 at 10 41 59" src="https://github.com/user-attachments/assets/a6d60c5f-fad1-4049-8b00-63b854a8afb2" />

### Why did it change
- To match changes made to the CRI in [this PR](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/88)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DCMAW-10940](https://govukverify.atlassian.net/browse/DCMAW-10940)

## Checklists
- [ ] Documented in the README
- [x] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

[DCMAW-10940]: https://govukverify.atlassian.net/browse/DCMAW-10940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ