### PR TITLE
BAU: create results directory only if it doesn't exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-bookworm-slim
 COPY . /
-RUN npm install && \
-    mkdir /results
+RUN mkdir -p /results
+RUN npm install
 EXPOSE 3001
 ENV PORT=3001
 ENTRYPOINT ["bash", "run_server_and_tests.sh"]


### PR DESCRIPTION
## Proposed changes
Use `mkdir -p /results` in the `Dockerfile` to create the directory only if it doesn't exist.

### Why did it change
To avoid running into an error in case the file exists locally and is copied over in the` COPY . /` command

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
