### PR TITLE
DCMAW-13556: Return 401 and 'invalid_token' for credential requests with invalid access tokens

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -78,7 +78,7 @@ describe("credential issuer tests", () => {
     JWKS = (await getJwks(CRI_URL)).data.keys;
   });
 
-  it("should return 400 and 'invalid_credential_request' when the access token and the credential offer wallet subject IDs do not match", async () => {
+  it("should return 401 and 'invalid_token' when the access token and the credential offer wallet subject IDs do not match", async () => {
     const accessTokenWithInvalidWalletSubjectId = (
       await createAccessToken(
         NONCE,
@@ -102,14 +102,14 @@ describe("credential issuer tests", () => {
         CREDENTIAL_ENDPOINT,
       );
     } catch (error) {
-      expect((error as AxiosError).response?.status).toEqual(400);
-      expect((error as AxiosError).response?.data).toEqual({
-        error: "invalid_credential_request",
-      });
+      expect((error as AxiosError).response?.status).toEqual(401);
+      expect(
+        (error as AxiosError).response?.headers["www-authenticate"],
+      ).toEqual('Bearer error="invalid_token"');
     }
   });
 
-  it("should return 400 and 'invalid_credential_request' when the access token signature is invalid", async () => {
+  it("should return 401 and 'invalid_token' when the access token signature is invalid", async () => {
     const accessToken = (
       await createAccessToken(
         NONCE,
@@ -134,10 +134,10 @@ describe("credential issuer tests", () => {
         CREDENTIAL_ENDPOINT,
       );
     } catch (error) {
-      expect((error as AxiosError).response?.status).toEqual(400);
-      expect((error as AxiosError).response?.data).toEqual({
-        error: "invalid_credential_request",
-      });
+      expect((error as AxiosError).response?.status).toEqual(401);
+      expect(
+        (error as AxiosError).response?.headers["www-authenticate"],
+      ).toEqual('Bearer error="invalid_token"');
     }
   });
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Corrected the HTTP status code and error message returned when an invalid access token is presented to the credential issuer. Previously, a 400 status code with an "invalid_credential_request" error was returned. This has been updated to return a 401 status code with a "WWW-Authenticate" header containing "Bearer error="invalid_token"".

### Why did it change

- To align the response with the OAuth 2.0 specification, which requires a 401 status code for invalid access tokens. 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13556](https://govukverify.atlassian.net/browse/DCMAW-13556)

## Testing

<img width="1139" alt="Screenshot 2025-05-29 at 11 58 13" src="https://github.com/user-attachments/assets/12df1549-6cbb-4d55-ac71-3d7ecc796f4b" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/215
https://github.com/govuk-one-login/mobile-wallet-tech-docs/pull/96

[DCMAW-13556]: https://govukverify.atlassian.net/browse/DCMAW-13556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ