### PR TITLE
DCMAW- 13552: Add tests for unauthorised notification requests

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -300,7 +300,35 @@ describe("credential issuer tests", () => {
       }
     });
 
-    it("should return 401 when the 'credential_accepted' notification sent does not contain authentication", async () => {
+    it("should return 401 when the 'credential_accepted' notification does not contain authentication", async () => {
+      if (!NOTIFICATION_ENDPOINT) {
+        console.log("CRI doesn't implement a notification endpoint");
+      } else {
+        const notification_id = response.data.notification_id;
+        try {
+          await axios.post(
+            getDockerDnsName(NOTIFICATION_ENDPOINT),
+            {
+              notification_id,
+              event: "credential_accepted",
+            },
+            {
+              headers: {
+                Authorization: "Bearer INVALID_TOKEN",
+              },
+            },
+          );
+        } catch (error) {
+          console.log(error);
+          expect((error as AxiosError).response?.status).toEqual(401);
+          expect(
+            (error as AxiosError).response?.headers["www-authenticate"],
+          ).toEqual('Bearer error="invalid_token"');
+        }
+      }
+    });
+
+    it("should return 401 when the 'credential_accepted' notification contains an invalid access token", async () => {
       if (!NOTIFICATION_ENDPOINT) {
         console.log("CRI doesn't implement a notification endpoint");
       } else {


### PR DESCRIPTION
## Proposed changes
### What changed

- Added two new tests to verify the behaviour of the notification endpoint when handling unauthorized requests:
  - **Invalid authentication**: check that a 401 Unauthorized status code with a "WWW-Authenticate" header containing "Bearer error="invalid_token"" is returned when a notification request is made with an invalid token.
  - **No authentication**: check that a 401 Unauthorized status code with a "WWW-Authenticate" header containing "Bearer" is returned when a notification request is made without any authentication information.

### Why did it change
- To ensure that the notification endpoint correctly enforces authentication requirements and provides appropriate error responses for unauthorised requests.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13552](https://govukverify.atlassian.net/browse/DCMAW-13552)

## Testing
<img width="1310" alt="Screenshot 2025-05-29 at 12 07 57" src="https://github.com/user-attachments/assets/aeec99bd-cf02-452d-be1a-995a757ebe67" />


## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/215
https://github.com/govuk-one-login/mobile-wallet-tech-docs/pull/95

[DCMAW-13552]: https://govukverify.atlassian.net/browse/DCMAW-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ