### PR TITLE
BAU: Fix Discrepancies and Failing Test

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -348,7 +348,7 @@ describe("credential issuer tests", () => {
     });
   });
 
-  it("should return 400 and 'invalid_credential_request' when the credential offer cannot be found in the database", async () => {
+  it("should return 401 and 'invalid_token' when the credential offer cannot be found in the database", async () => {
     const proofJwt = await createProofJwt(
       NONCE,
       createDidKey(PUBLIC_KEY_JWK),
@@ -366,10 +366,10 @@ describe("credential issuer tests", () => {
     try {
       await getCredential(accessToken, proofJwt, CREDENTIAL_ENDPOINT);
     } catch (error) {
-      expect((error as AxiosError).response?.status).toEqual(400);
-      expect((error as AxiosError).response?.data).toEqual({
-        error: "invalid_credential_request",
-      });
+      expect((error as AxiosError).response?.status).toEqual(401);
+      expect(
+        (error as AxiosError).response?.headers["www-authenticate"],
+      ).toEqual('Bearer error="invalid_token"');
     }
   });
 });

--- a/test/helpers/credentialOffer/credentialOfferSchema.ts
+++ b/test/helpers/credentialOffer/credentialOfferSchema.ts
@@ -12,6 +12,7 @@ export const credentialOfferSchema = {
         minLength: 1,
       },
       minItems: 1,
+      maxItems: 1,
     },
     grants: {
       type: "object",

--- a/test/helpers/credentialOffer/validateCredentialOffer.ts
+++ b/test/helpers/credentialOffer/validateCredentialOffer.ts
@@ -4,7 +4,7 @@ import { credentialOfferSchema } from "./credentialOfferSchema";
 
 export interface CredentialOffer {
   credential_issuer: string;
-  credentials: string[];
+  credential_configuration_ids: string[];
   grants: Grants;
 }
 


### PR DESCRIPTION
## Proposed changes
### What changed
- Updated test description and assertion: CRI should return 401 and `invalid_token` when it can't find the credential offer
- Added an upper limit of 1 item to the credential offer `credential_configuration_ids` array as each credential offer is issued for only one credential type, not multiple.
- Renamed `credentials` to `credential_configuration_ids` in the credential offer interface - relates to https://govukverify.atlassian.net/browse/DCMAW-13548

### Why did it change
<!-- Describe the reason these changes were made -->

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<img width="1068" alt="Screenshot 2025-06-16 at 12 29 28" src="https://github.com/user-attachments/assets/eafce77d-9b0b-4bcd-9781-9809bc4287b4" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
