### PR TITLE
DCMAW-13554 Update the @context value in the Did Document test

### DIFF
--- a/test/helpers/didDocument/validateDidDocument.test.ts
+++ b/test/helpers/didDocument/validateDidDocument.test.ts
@@ -16,7 +16,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         verificationMethod: [
@@ -83,7 +83,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         verificationMethod: [
@@ -134,7 +134,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         assertionMethod: [
@@ -157,7 +157,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:SOMETHING-ELSE.test.gov.uk",
         verificationMethod: [
@@ -195,7 +195,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         verificationMethod: [
@@ -233,7 +233,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         verificationMethod: [
@@ -284,7 +284,7 @@ describe("validateDidDocument", () => {
       data: {
         "@context": [
           "https://www.w3.org/ns/did/v1",
-          "https://www.w3.org/ns/security/jwk/v1",
+          "https://w3id.org/security/suites/jws-2020/v1",
         ],
         id: "did:web:example-cri.test.gov.uk",
         verificationMethod: [


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Updated one of the values of @context property to be "https://w3id.org/security/suites/jws-2020/v1" 


### Why did it change
<!-- Describe the reason these changes were made -->
The current DID document returned by the did:web API uses an incorrect value for the @context property. This needs to be updated to align with the [did:web method specification](https://w3c-ccg.github.io/did-method-web/).

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13554](https://govukverify.atlassian.net/browse/DCMAW-13554)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
<img width="1150" alt="Screenshot 2025-07-02 at 15 14 04" src="https://github.com/user-attachments/assets/0b3317ba-5cc8-4c83-9e31-fe22df4164af" />

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13554]: https://govukverify.atlassian.net/browse/DCMAW-13554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ