### PR TITLE
DCMAW-13557 Update credential-issuer-test to return invalid_nonce

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -174,7 +174,7 @@ describe("credential issuer tests", () => {
     }
   });
 
-  it("should return 400 and 'invalid_proof' when the proof JWT nonce does not match the access token c_nonce", async () => {
+  it("should return 400 and 'invalid_nonce' when the proof JWT nonce does not match the access token c_nonce", async () => {
     const proofJwtWithMismatchingNonce = await createProofJwt(
       "not_the_same_nonce",
       createDidKey(PUBLIC_KEY_JWK),
@@ -199,7 +199,7 @@ describe("credential issuer tests", () => {
     } catch (error) {
       expect((error as AxiosError).response?.status).toEqual(400);
       expect((error as AxiosError).response?.data).toEqual({
-        error: "invalid_proof",
+        error: "invalid_nonce",
       });
     }
   });


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Update credential-issuer-test to return `invalid_nonce` when the proof JWT nonce does not match the access token c_nonce.

### Why did it change
<!-- Describe the reason these changes were made -->
The Credential API currently returns a 400 Bad Request status code for credential request errors, but does not include the specific error codes defined in the specification. This implementation aims to ensure that appropriate error codes are returned as per the [OID4VCI specification](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-8.3.1.2).
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13557](https://govukverify.atlassian.net/browse/DCMAW-13557)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Tested locally
<img width="1193" alt="Screenshot 2025-07-09 at 10 23 44" src="https://github.com/user-attachments/assets/dfb65c1a-c96a-4dfa-bc71-accf17afe584" />

## Checklist
- [ ] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13557]: https://govukverify.atlassian.net/browse/DCMAW-13557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ