### PR TITLE
DCMAW-13563 Update Credential payload Schema

### DIFF
--- a/test/helpers/credential/payloadSchema.ts
+++ b/test/helpers/credential/payloadSchema.ts
@@ -80,10 +80,10 @@ export const payloadSchema = {
   required: [
     "iss",
     "sub",
-    "nbf",
     "@context",
     "type",
     "issuer",
+    "validUntil",
     "credentialSubject",
   ],
 };


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->

- Update Credential payload Schema to have `validUntil` as required claim

- Update Credential payload Schema and remove `nbf` as required claim

### Why did it change
<!-- Describe the reason these changes were made -->
To align with recent updates that have changed the definitions of the exp (expiration time) and validUntil claims for JWT credentials, and the Example CRI has been revised accordingly. These updates are also aligned with RFC 0090 that defines which credential claims are required and which are optional. 

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-13563](https://govukverify.atlassian.net/browse/DCMAW-13563)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

<img width="746" height="462" alt="Screenshot 2025-07-11 at 12 01 31" src="https://github.com/user-attachments/assets/7766b58b-c99e-4551-b17b-7df90a53db1e" />


## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-13563]: https://govukverify.atlassian.net/browse/DCMAW-13563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ