### PR TITLE
Partially revert "build: validate PR title and bump release version"

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,4 +1,4 @@
-name: Code Quality Analysis & Docker Image Scan
+name: Nightly Quality Analysis & Docker Image Vulnerability Scan
 
 on:
   schedule:
@@ -11,8 +11,8 @@ permissions:
 
 jobs:
   sonarqube-scan:
-    name: SonarQube
-    runs-on: ubuntu-latest
+    name: SonarQube scan
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,12 +1,16 @@
-name: Pull-Request Checks
+name: Pull-Request
 
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-lint-and-test:
     name: Build, lint and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Partially reverts govuk-one-login/mobile-wallet-cri-test-harness#295

- Remove Release workflow 
- Remove step from Pull Request workflow to validate the pull request name 