### PR TITLE
build: create release only if version has been bumped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Proposed changes
### What changed
- Add steps to the Release GitHub Actions workflow to:
  - Get the most recent tag 
  - Check if cocogitto created a new semantic release
  - If new semantic release created, then push semantic version tag and create GitHub release

### Why did it change
- To push tags and created GitHub releases only when cocogitto has created a new semantic release

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-14662](https://govukverify.atlassian.net/browse/DCMAW-14662)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->


[DCMAW-14662]: https://govukverify.atlassian.net/browse/DCMAW-14662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ