### PR TITLE
feat!: migrate from CommonJS (CJS) to ES Modules (ESM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "license": "MIT",
   "main": "src/server.ts",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "execute": "node ./dist/src/server.js",
@@ -12,7 +13,7 @@
     "lint": "eslint . ",
     "lint:fix": "eslint . --fix",
     "format": "prettier --ignore-path .gitignore --write \"*/**/*.{ts,json}\"",
-    "test": "node_modules/.bin/jest  --testPathPatterns=test/credential-issuer-tests.test.ts --coverage=false",
+    "test": "node_modules/.bin/jest --testPathPatterns=test/credential-issuer-tests.test.ts --coverage=false",
     "test:unit": "TZ=UTC jest node_modules/.bin/jest --testPathPatterns=test/helpers src/config --silent"
   },
   "dependencies": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,5 @@
 import express, { Application, Request, Response } from "express";
-import { getKeyId, getPortNumber } from "./config";
+import { getKeyId, getPortNumber } from "./config.js";
 import { generateKeyPair, exportJWK, JWK } from "jose";
 import { writeFileSync } from "fs";
 
@@ -16,7 +16,7 @@ app.get("/.well-known/jwks.json", async (_req: Request, res: Response) => {
   res.status(200).json(response);
 });
 
-const server = app
+export const server = app
   .listen(port, async () => {
     console.log(`Server is running on port ${port}`);
 
@@ -41,5 +41,3 @@ const server = app
   .on("error", (error: Error) => {
     console.log(error, "Unable to start server");
   });
-
-module.exports = server;

--- a/test/helpers/credential/createProofJwt.ts
+++ b/test/helpers/credential/createProofJwt.ts
@@ -1,5 +1,5 @@
 import { importJWK, JWK, JWTPayload, SignJWT } from "jose";
-import bs58 = require("bs58");
+import bs58 from "bs58";
 
 const SIGNING_ALGORITHM = "ES256";
 const PROOF_JWT_ISSUER = "urn:fdc:gov:uk:wallet";
@@ -30,7 +30,7 @@ export function createDidKey(publicKeyJwk: JWK): string {
   bytes[1] = 0x24;
   bytes.set(compressedPublicKey, 2);
 
-  const base58EncodedKey = bs58.default.encode(bytes);
+  const base58EncodedKey = bs58.encode(bytes);
   return `did:key:z${base58EncodedKey}`;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2019",             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "ES2022",             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "ESNext",             /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "sourceMap": true,              /* Generates corresponding '.map' file. */
     "outDir": "./dist",             /* Redirect output structure to the directory. */
     "strict": true,                 /* Enable all strict type-checking options. */


### PR DESCRIPTION
## Proposed changes
### What changed
- Add `"type": "module"` in the `package.json` to indicate ESM usage
- Update the `tsconfig.json`:
  - Set `"module": "ESNext"`
  - Set `"target": "ES2022"`
- Convert all `require` into `import` statements
- Add file extension (`.js`) to app code imports

### Why did it change
- To align the project with the modern JavaScript module standard

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing
<img width="1136" height="482" alt="Screenshot 2025-08-13 at 17 42 45" src="https://github.com/user-attachments/assets/0bc6978f-6cfd-48fc-bfeb-5d354e26f361" />

<img width="655" height="126" alt="image" src="https://github.com/user-attachments/assets/8f5b6aca-03ab-45aa-b05a-8e674207d59b" />

## Checklist
- [x] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
