### PR TITLE
fix: add `jti` and `exp` to mock access token

### DIFF
--- a/test/helpers/credential/createAccessToken.test.ts
+++ b/test/helpers/credential/createAccessToken.test.ts
@@ -1,26 +1,41 @@
 import { createAccessToken } from "./createAccessToken";
 import { decodeJwt, decodeProtectedHeader } from "jose";
+import crypto from "crypto";
+
+const c_nonce = "e4cedcf6-1fb1-48f8-bf74-94cfbe9d0d86";
+const walletSubjectId = "wallet_subject_id";
+const preAuthorizedCodePayload = {
+  aud: "urn:fdc:gov:uk:wallet",
+  clientId: "EXAMPLE_CRI",
+  iss: "urn:fdc:gov:uk:example-credential-issuer",
+  credential_identifiers: ["e0b02438-d006-4100-918a-b02629e1e29c"],
+  exp: 1721223394,
+  iat: 1721223094,
+};
+const privateKeyJwk = {
+  kty: "EC",
+  x: "MMDgSI-XZWGzTCuPXwJerzvcvn93CJTe8ARsb0oLZw8",
+  y: "VexEnyluTVBOrT_0ZOmNTl2ab9CXFTvb4BDIB93Mv7g",
+  crv: "P-256",
+  d: "K7DmYFhkGoXdwBROSL2mZvcNxONlhBQj5kV7yevigtk",
+};
+const accessTokenTtlInSeconds = 180;
 
 describe("createAccessToken", () => {
-  it("should return the access token", async () => {
-    const c_nonce = "e4cedcf6-1fb1-48f8-bf74-94cfbe9d0d86";
-    const walletSubjectId = "wallet_subject_id";
-    const preAuthorizedCodePayload = {
-      aud: "urn:fdc:gov:uk:wallet",
-      clientId: "EXAMPLE_CRI",
-      iss: "urn:fdc:gov:uk:example-credential-issuer",
-      credential_identifiers: ["e0b02438-d006-4100-918a-b02629e1e29c"],
-      exp: 1721223394,
-      iat: 1721223094,
-    };
-    const privateKeyJwk = {
-      kty: "EC",
-      x: "MMDgSI-XZWGzTCuPXwJerzvcvn93CJTe8ARsb0oLZw8",
-      y: "VexEnyluTVBOrT_0ZOmNTl2ab9CXFTvb4BDIB93Mv7g",
-      crv: "P-256",
-      d: "K7DmYFhkGoXdwBROSL2mZvcNxONlhBQj5kV7yevigtk",
-    };
+  const mockTimestamp = 1234567890123;
+  const mockedJti = "11c70ee6-d3d9-42f5-8232-548385fb58a0";
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+    jest.spyOn(crypto, "randomUUID").mockReturnValue(mockedJti);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should return the access token", async () => {
     const response = await createAccessToken(
       c_nonce,
       walletSubjectId,
@@ -32,8 +47,21 @@ describe("createAccessToken", () => {
     const accessTokenHeader = decodeProtectedHeader(response.access_token);
 
     expect(response.token_type).toEqual("bearer");
-    expect(response.expires_in).toEqual(180);
+    expect(response.expires_in).toEqual(accessTokenTtlInSeconds);
     expect(response.access_token).toBeTruthy();
+
+    const requiredPayloadClaims = [
+      "sub",
+      "aud",
+      "iss",
+      "c_nonce",
+      "credential_identifiers",
+      "exp",
+      "jti",
+    ];
+    requiredPayloadClaims.forEach((claim) => {
+      expect(accessTokenPayload).toHaveProperty(claim);
+    });
     expect(accessTokenPayload.sub).toEqual(walletSubjectId);
     expect(accessTokenPayload.aud).toEqual(preAuthorizedCodePayload.iss);
     expect(accessTokenPayload.iss).toEqual(preAuthorizedCodePayload.aud);
@@ -41,7 +69,16 @@ describe("createAccessToken", () => {
     expect(accessTokenPayload.credential_identifiers).toEqual(
       preAuthorizedCodePayload.credential_identifiers,
     );
-    expect(accessTokenPayload.c_nonce).toEqual(c_nonce);
+    expect(accessTokenPayload.jti).toEqual(mockedJti);
+    const mockedNowInSeconds = Math.floor(Date.now() / 1000);
+    expect(accessTokenPayload.exp).toEqual(
+      mockedNowInSeconds + accessTokenTtlInSeconds,
+    );
+
+    const requiredHeaderClaims = ["kid", "typ", "alg"];
+    requiredHeaderClaims.forEach((claim) => {
+      expect(accessTokenHeader).toHaveProperty(claim);
+    });
     expect(accessTokenHeader.kid).toEqual(
       "5d76b492-d62e-46f4-a3d9-bc51e8b91ac5",
     );

--- a/test/helpers/credential/createAccessToken.ts
+++ b/test/helpers/credential/createAccessToken.ts
@@ -1,5 +1,6 @@
 import { importJWK, SignJWT, JWK, JWTPayload } from "jose";
 import { getKeyId } from "../../../src/config";
+import { randomUUID } from "node:crypto";
 
 export interface AccessToken {
   access_token: string;
@@ -8,6 +9,7 @@ export interface AccessToken {
 }
 
 const SIGNING_ALGORITHM = "ES256";
+const TTL = 180;
 
 export async function createAccessToken(
   c_nonce: string,
@@ -20,7 +22,7 @@ export async function createAccessToken(
     credential_identifiers: preAuthorizedCodePayload.credential_identifiers!,
     c_nonce: c_nonce,
   };
-
+  const nowInSeconds = Math.floor(Date.now() / 1000);
   const accessToken = await new SignJWT(customClaims)
     .setProtectedHeader({
       alg: SIGNING_ALGORITHM,
@@ -30,11 +32,13 @@ export async function createAccessToken(
     .setSubject(walletSubjectId)
     .setIssuer(preAuthorizedCodePayload.aud! as string)
     .setAudience(preAuthorizedCodePayload.iss!)
+    .setJti(randomUUID())
+    .setExpirationTime(nowInSeconds + TTL)
     .sign(signingKeyAsKeyLike);
 
   return {
     access_token: accessToken,
     token_type: "bearer",
-    expires_in: 180,
+    expires_in: TTL,
   };
 }


### PR DESCRIPTION
## Proposed changes
### What changed
- Add `jti` and `exp` claims to mock access token payload.

### Why did it change
- Previously missing.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-15228](https://govukverify.atlassian.net/browse/DCMAW-15228)

## Testing
- Unit testing only

## Checklist
- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
https://github.com/govuk-one-login/mobile-wallet-tech-docs/pull/136
https://github.com/govuk-one-login/mobile-wallet-document-builder/pull/293
https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/pull/327

[DCMAW-15228]: https://govukverify.atlassian.net/browse/DCMAW-15228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ