### PR TITLE
fix: www-authenticate header to accept optional parameters

### DIFF
--- a/test/credential-issuer-tests.test.ts
+++ b/test/credential-issuer-tests.test.ts
@@ -541,9 +541,12 @@ describe("Credential Issuer Tests", () => {
             );
           } catch (error) {
             expect((error as AxiosError).response?.status).toEqual(401);
-            expect(
-              (error as AxiosError).response?.headers["www-authenticate"],
-            ).toEqual("Bearer");
+            const header = (error as AxiosError).response?.headers[
+              "www-authenticate"
+            ];
+            expect(wwwAuthenticateHeaderContainsCorrectError(header)).toBe(
+              true,
+            );
           }
         });
       });

--- a/test/helpers/credential/www-Authenticate.test.ts
+++ b/test/helpers/credential/www-Authenticate.test.ts
@@ -37,11 +37,7 @@ describe("www-Authenticate", () => {
     ).toBe(false);
   });
 
-  it("should not match if error is missing or different", () => {
-    expect(wwwAuthenticateHeaderContainsCorrectError('Bearer realm=""')).toBe(
-      false,
-    );
-
+  it("should not match if error is different", () => {
     expect(
       wwwAuthenticateHeaderContainsCorrectError(
         'Bearer error="different error"',
@@ -53,5 +49,17 @@ describe("www-Authenticate", () => {
         'Bearer blaherror="invalid_token"',
       ),
     ).toBe(false);
+  });
+
+  it("should match if it start with Bearer and have only realm", () => {
+    expect(
+      wwwAuthenticateHeaderContainsCorrectError(
+        'Bearer realm="http://localhost:8000"',
+      ),
+    ).toBe(true);
+  });
+
+  it("should match if there are no parameter", () => {
+    expect(wwwAuthenticateHeaderContainsCorrectError("Bearer")).toBe(true);
   });
 });

--- a/test/helpers/credential/www-Authenticate.ts
+++ b/test/helpers/credential/www-Authenticate.ts
@@ -1,6 +1,8 @@
 export function wwwAuthenticateHeaderContainsCorrectError(
   header: string,
 ): boolean {
+  if (header === "Bearer") return true;
   if (!header.startsWith("Bearer ")) return false;
+  if (header.includes("realm")) return true;
   return /\berror="invalid_token"/.test(header);
 }


### PR DESCRIPTION
## Proposed changes
### What changed
<!-- Describe the changes made -->
- Update helper function to allow for missing parameters like `realm` and `error`.
- Add new tests and update existing tests.
### Why did it change
<!-- Describe the reason these changes were made -->
With this implementation, `www-authenticate` in response header allows parameters to be optionally present.  
### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-16032](https://govukverify.atlassian.net/browse/DCMAW-16032)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->
##### Testing mdoc credential 
<img width="645" height="598" alt="Screenshot 2025-10-08 at 12 38 05" src="https://github.com/user-attachments/assets/d3513a99-921d-4cb9-8967-20e47bbeb7c6" />

##### Testing JWT credential
<img width="620" height="592" alt="Screenshot 2025-10-08 at 12 39 24" src="https://github.com/user-attachments/assets/ee1206ac-a5b4-4b25-a1a2-cc884955df30" />

##### Unit tests for helper function
<img width="421" height="86" alt="Screenshot 2025-10-08 at 12 52 28" src="https://github.com/user-attachments/assets/36c7c31b-9924-4333-b220-0e6a7f0d40e0" />

## Checklist

- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
