### PR TITLE
docs: rewrite readme for test harness repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This service is built with TypeScript and Node.js/Express, and it is containeris
 
 - [Node.js](https://nodejs.org/en) — we recommend managing versions with [nvm](https://github.com/nvm-sh/nvm)
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) — must be installed on your machine.
+- [pre-commit](https://pre-commit.com/)
 
 ## Local Setup
 
@@ -80,11 +81,7 @@ npm run format
 
 ### Run
 
-Running locally also requires:
-
-- [Document Builder](https://github.com/govuk-one-login/mobile-wallet-document-builder)
-- [Example CRI](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/tree/main/example-credential-issuer)
-- [Status List Mock](https://github.com/govuk-one-login/mobile-wallet-status-list-mock)
+Running locally also requires Example Credential Issuer to test it.
 
 Run the test harness with your credential format and credential offer deep link:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This service is built with TypeScript and Node.js/Express, and it is containeris
 
 ### Install
 
+```bash
+npm install
+```
+
 ### Pre-commit Hooks
 
 This project uses [pre-commit](https://pre-commit.com/) to run checks before commits and pushes. Set it up with:

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ pre-commit install --hook-type pre-push
 
 ### Lint & Format
 
+```bash
+npm run lint:fix
+npm run format
+```
+
 ## Run
 
 ### Configure credential issuer

--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ npm run test:unit
 
 ## Contributing
 
-Pre-commit hooks are used to maintain code quality and validate commit messages against the [Conventional Commits](https://github.com/conventional-changelog/commitlint) standard — non-conforming messages will be rejected.
+We use pre-commit hooks to maintain code quality and validate commit messages against the [Conventional Commits](https://github.com/conventional-changelog/commitlint) standard. If your message does not conform to these standards, it will be rejected.
 
 Ensure your branch is up to date and all hooks pass before opening a pull request. Avoid using the git `--no-verify` flag to skip these checks unless absolutely necessary.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ The test script:
 - builds a Docker image (`test-harness`) containing all dependencies and test code
 - runs a Docker container, mounting an output directory for test results and passing required configuration via environment variables
 
-### Execute tests
+### Test
+
+Local tests:
+
+```bash
+npm run test:unit
+```
 
 The container runs the `run-server-and-tests.sh` script, which:
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This service is built with TypeScript and Node.js/Express, and it is containeris
 npm install
 ```
 
-### Pre-commit Hooks
+### Pre-commit hooks
 
 This project uses [pre-commit](https://pre-commit.com/) to run checks before commits and pushes. Set it up with:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The container runs the `run-server-and-tests.sh` script, which:
 
 You must set up your credential issuer so that it uses the test harness domain to fetch the public signing key that validates the credential access token.
 
-When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-a-credential/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
+When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-credentials/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
 
 Run the test harness with your credential format and credential offer deep link:
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ npm run format
 
 ### Run
 
+Before running the test harness, you must set up your credential issuer so that it
+uses the test harness domain to fetch the public signing key that validates the
+credential access token.
+
 The container runs the `run-server-and-tests.sh` script, which:
 
 - starts the test server (`run-server.sh`)
@@ -94,8 +98,6 @@ The container runs the `run-server-and-tests.sh` script, which:
 - saves test results in `./output/report.xml`
 
 ### Configure credential issuer
-
-You must set up your credential issuer so that it uses the test harness domain to fetch the public signing key that validates the credential access token.
 
 When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-credentials/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ npm run format
 
 ### Run
 
+The container runs the `run-server-and-tests.sh` script, which:
+
+- starts the test server (`run-server.sh`)
+- waits 5 seconds for the server to start
+- executes the test suite (`run-tests.sh`) against the credential issuer
+- exits when the test suite finishes executing
+- saves test results in `./output/report.xml`
+
 ### Configure credential issuer
 
 You must set up your credential issuer so that it uses the test harness domain to fetch the public signing key that validates the credential access token.
@@ -127,21 +135,9 @@ The test script:
 
 ### Test
 
-Local tests:
-
 ```bash
 npm run test:unit
 ```
-
-Execute tests:
-
-The container runs the `run-server-and-tests.sh` script, which:
-
-- starts the test server (`run-server.sh`)
-- waits 5 seconds for the server to start
-- executes the test suite (`run-tests.sh`) against the credential issuer
-- exits when the test suite finishes executing
-- saves test results in `./output/report.xml`
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ You must set up your credential issuer so that it uses the test harness domain t
 
 When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-a-credential/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
 
-Running locally also requires Example Credential Issuer to test it.
-
 Run the test harness with your credential format and credential offer deep link:
 
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ pre-commit install --hook-type commit-msg
 pre-commit install --hook-type pre-push
 ```
 
-### Lint & Format
+### Lint and Format
 
 ```bash
 npm run lint:fix
@@ -140,7 +140,7 @@ The container runs the `run-server-and-tests.sh` script, which:
 npm run test:unit
 ```
 
-## Contributing
+## Contribute
 
 We use pre-commit hooks to maintain code quality and validate commit messages against the [Conventional Commits](https://github.com/conventional-changelog/commitlint) standard. If your message does not conform to these standards, it will be rejected.
 

--- a/README.md
+++ b/README.md
@@ -78,23 +78,13 @@ npm run lint:fix
 npm run format
 ```
 
-## Run
+### Run
 
-### Configure credential issuer
+Running locally also requires:
 
-You must set up your credential issuer so that it uses the test harness domain to fetch the public signing key that validates the credential access token.
-
-When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-a-credential/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
-
-### Get test harness files
-
-Clone the repo:
-
-```
-git clone git@github.com:govuk-one-login/mobile-wallet-cri-test-harness.git
-```
-
-### Run test script
+- [Document Builder](https://github.com/govuk-one-login/mobile-wallet-document-builder)
+- [Example CRI](https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer/tree/main/example-credential-issuer)
+- [Status List Mock](https://github.com/govuk-one-login/mobile-wallet-status-list-mock)
 
 Run the test harness with your credential format and credential offer deep link:
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This service is built with TypeScript and Node.js/Express, and it is containeris
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) — must be installed on your machine.
 - [pre-commit](https://pre-commit.com/)
 
-## Local Setup
+## Set up locally
 
 ### Install
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The test harness takes your credential offer as its input and validates it, then
 
 The test harness simulates valid and invalid calls to the:
 
-- issuer [metadata API](https://docs.wallet.service.gov.uk/issue-a-credential/metadata/) (`/.well-known/openid-credential-issuer`)
-- [credential API](https://docs.wallet.service.gov.uk/issue-a-credential/credential/) (path taken from issuer metadata API)
-- [JWKS API](https://docs.wallet.service.gov.uk/issue-a-credential/jwks/) (`/.well-known/jwks.json`)
-- [did:web API](https://docs.wallet.service.gov.uk/issue-a-credential/did/) (`/.well-known/did.json`)
+- issuer [metadata API](https://docs.wallet.service.gov.uk/issue-credentials/metadata/) (`/.well-known/openid-credential-issuer`)
+- [credential API](https://docs.wallet.service.gov.uk/issue-credentials/credential/) (path taken from issuer metadata API)
+- [JWKS API](https://docs.wallet.service.gov.uk/issue-credentials/jwks/) (`/.well-known/jwks.json`)
+- [did:web API](https://docs.wallet.service.gov.uk/issue-credentials/did/) (`/.well-known/did.json`)
 - IACAS API (`/.well-known/iacas`)
-- [notification API](https://docs.wallet.service.gov.uk/issue-a-credential/notification/) (path taken from issuer metadata API)
+- [notification API](https://docs.wallet.service.gov.uk/issue-credentials/notification/) (path taken from issuer metadata API)
 
 After simulating calls to these endpoints, the test harness validates the responses returned by checking that:
 

--- a/README.md
+++ b/README.md
@@ -89,14 +89,6 @@ Before running the test harness, you must set up your credential issuer so that 
 uses the test harness domain to fetch the public signing key that validates the
 credential access token.
 
-The container runs the `run-server-and-tests.sh` script, which:
-
-- starts the test server (`run-server.sh`)
-- waits 5 seconds for the server to start
-- executes the test suite (`run-tests.sh`) against the credential issuer
-- exits when the test suite finishes executing
-- saves test results in `./output/report.xml`
-
 ### Configure credential issuer
 
 When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-credentials/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
@@ -131,7 +123,16 @@ For example:
 The test script:
 
 - builds a Docker image (`test-harness`) containing all dependencies and test code
-- runs a Docker container, mounting an output directory for test results and passing required configuration via environment variables
+- runs a Docker container, mounting an output directory for test results and passing
+  required configuration via environment variables
+
+The container runs the `run-server-and-tests.sh` script, which:
+
+- starts the test server (`run-server.sh`)
+- waits 5 seconds for the server to start
+- executes the test suite (`run-tests.sh`) against the credential issuer
+- exits when the test suite finishes executing
+- saves test results in `./output/report.xml`
 
 ### Test
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,12 @@ If you have questions or suggestions, contact us on [govukwallet-queries@digital
 
 ## Tech Stack
 
-[Docker](https://docs.docker.com/get-started/get-docker/) must be installed on your machine.
+This service is built with TypeScript and Node.js/Express, and it is containerised with Docker.
 
 ### Prerequisites
+
+- [Node.js](https://nodejs.org/en) — we recommend managing versions with [nvm](https://github.com/nvm-sh/nvm)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) — must be installed on your machine.
 
 ## Local Setup
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,28 @@ When the test harness finishes testing, it produces a test report detailing the 
 
 The test harness does not test all possible unhappy paths.
 
-## Before you start
+## Disclaimers
+
+- This implementation supports the credential issuance journeys as specified in the [GOV.UK Wallet technical documentation](https://docs.wallet.service.gov.uk/).
+- This is not production code.
+- You should check that you are using the latest version of this implementation.
+- This implementation may change, add or remove features, which may make it incompatible with your code.
+- This implementation is limited in scope.
+- This implementation must not replace your own testing - you must perform sufficient testing to properly evaluate your application and its production readiness.
+
+## Contact us
+
+If you have questions or suggestions, contact us on [govukwallet-queries@digital.cabinet-office.gov.uk](mailto:govukwallet-queries@digital.cabinet-office.gov.uk) or use #govuk-wallet in x-gov Slack.
+
+## Tech Stack
 
 [Docker](https://docs.docker.com/get-started/get-docker/) must be installed on your machine.
+
+### Prerequisites
+
+## Local Setup
+
+### Install
 
 ### Pre-commit Hooks
 
@@ -49,7 +68,9 @@ pre-commit install --hook-type commit-msg
 pre-commit install --hook-type pre-push
 ```
 
-## Run the test harness
+### Lint & Format
+
+## Run
 
 ### Configure credential issuer
 
@@ -108,19 +129,6 @@ The container runs the `run-server-and-tests.sh` script, which:
 - executes the test suite (`run-tests.sh`) against the credential issuer
 - exits when the test suite finishes executing
 - saves test results in `./output/report.xml`
-
-## Disclaimers
-
-- This implementation supports the credential issuance journeys as specified in the [GOV.UK Wallet technical documentation](https://docs.wallet.service.gov.uk/).
-- This is not production code.
-- You should check that you are using the latest version of this implementation.
-- This implementation may change, add or remove features, which may make it incompatible with your code.
-- This implementation is limited in scope.
-- This implementation must not replace your own testing - you must perform sufficient testing to properly evaluate your application and its production readiness.
-
-## Contact us
-
-If you have questions or suggestions, contact us on [govukwallet-queries@digital.cabinet-office.gov.uk](mailto:govukwallet-queries@digital.cabinet-office.gov.uk) or use #govuk-wallet in x-gov Slack.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ npm run format
 
 ### Run
 
+### Configure credential issuer
+
+You must set up your credential issuer so that it uses the test harness domain to fetch the public signing key that validates the credential access token.
+
+When configuring your pre-authorised code’s [JWT payload](https://docs.wallet.service.gov.uk/issue-a-credential/credential-offer/#jwt-payload), make sure the `aud` claim is set to the test harness domain (not the GOV.UK One Login authorisation server).
+
 Running locally also requires Example Credential Issuer to test it.
 
 Run the test harness with your credential format and credential offer deep link:

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Local tests:
 npm run test:unit
 ```
 
+Execute tests:
+
 The container runs the `run-server-and-tests.sh` script, which:
 
 - starts the test server (`run-server.sh`)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The test harness does not test all possible unhappy paths.
 
 If you have questions or suggestions, contact us on [govukwallet-queries@digital.cabinet-office.gov.uk](mailto:govukwallet-queries@digital.cabinet-office.gov.uk) or use #govuk-wallet in x-gov Slack.
 
-## Tech Stack
+## Tech stack
 
 This service is built with TypeScript and Node.js/Express, and it is containerised with Docker.
 


### PR DESCRIPTION
## Proposed changes

### What changed
Rewrote readme for test harness repository.

### Why did it change
To make it easier for anyone working on the service to find relevant information quickly, without having to navigate deployment steps or external dependency setup that don't belong in this repo.

### Issue tracking
- [DCMAW-19391](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing

## Checklist

- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [x] Documentation (e.g. README.md) has been updated

[DCMAW-19391]: https://govukverify.atlassian.net/browse/DCMAW-19391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ