### PR TITLE
feat: make credential_refresh_web_journey_url mandatory

### DIFF
--- a/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
+++ b/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
@@ -313,6 +313,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
           cryptographic_binding_methods_supported: ["cose_key"],
           credential_signing_alg_values_supported: ["ES256"],
           credential_validity_period_max_days: 30,
+          credential_refresh_web_journey_url: "https://example.com/refresh",
           extra_property: "allowed",
         },
       };
@@ -335,6 +336,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -360,6 +362,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -387,6 +390,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -417,6 +421,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -447,6 +452,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -476,6 +482,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -505,6 +512,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -539,6 +547,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -569,6 +578,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -599,6 +609,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -632,6 +643,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -652,6 +664,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["something_else"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -685,6 +698,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -704,6 +718,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -726,6 +741,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -750,6 +766,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["something_else"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
         const isValid = validate(data);
@@ -775,6 +792,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -794,6 +812,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
           cryptographic_binding_methods_supported: ["cose_key"],
           credential_signing_alg_values_supported: ["ES256"],
           credential_validity_period_max_days: 30,
+          credential_refresh_web_journey_url: "https://example.com/refresh",
         },
         SocialSecurityCredential: {
           format: "jwt_vc_json",
@@ -808,6 +827,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
           cryptographic_binding_methods_supported: ["did:key"],
           credential_signing_alg_values_supported: ["ES256"],
           credential_validity_period_max_days: 30,
+          credential_refresh_web_journey_url: "https://example.com/refresh",
         },
       };
 
@@ -824,6 +844,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
           cryptographic_binding_methods_supported: ["cose_key"],
           credential_signing_alg_values_supported: ["ES256"],
           credential_validity_period_max_days: 30,
+          credential_refresh_web_journey_url: "https://example.com/refresh",
         },
         SocialSecurityCredential: {
           format: "jwt_vc_json",
@@ -838,6 +859,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
           cryptographic_binding_methods_supported: ["did:key"],
           credential_signing_alg_values_supported: ["ES256"],
           credential_validity_period_max_days: 30,
+          credential_refresh_web_journey_url: "https://example.com/refresh",
         },
       };
 

--- a/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
+++ b/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
@@ -249,9 +249,6 @@ describe("credentialConfigurationsSupportedSchema", () => {
         );
       });
     });
-  });
-
-  describe("Optional Properties", () => {
     describe("credential_refresh_web_journey_url", () => {
       it("should return false if it is not a valid URI", () => {
         const data = {

--- a/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
+++ b/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
@@ -260,6 +260,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
         );
       });
     });
+
     describe("credential_refresh_web_journey_url", () => {
       it("should return false if it is not a valid URI", () => {
         const data = {
@@ -300,6 +301,29 @@ describe("credentialConfigurationsSupportedSchema", () => {
         const isValid = validate(data);
 
         expect(isValid).toBe(true);
+      });
+
+      it("should return false if it is missing", () => {
+        const data = {
+          "org.iso.18013.5.1.mDL": {
+            format: "mso_mdoc",
+            doctype: "org.iso.18013.5.1.mDL",
+            cryptographic_binding_methods_supported: ["cose_key"],
+            credential_signing_alg_values_supported: ["ES256"],
+            credential_validity_period_max_days: 30,
+          },
+        };
+
+        const isValid = validate(data);
+
+        expect(isValid).toBe(false);
+        expect(validate.errors).toContainEqual(
+          expect.objectContaining({
+            instancePath: "/org.iso.18013.5.1.mDL",
+            message:
+              "must have required property 'credential_refresh_web_journey_url'",
+          }),
+        );
       });
     });
   });

--- a/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
+++ b/test/helpers/metadata/credentialConfigurationsSupportedSchema.test.ts
@@ -14,6 +14,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -36,6 +37,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -61,6 +63,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: undefined,
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -84,6 +87,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: [],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -107,6 +111,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key", "did:key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -125,6 +130,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             credential_signing_alg_values_supported: undefined,
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -148,6 +154,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: [],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -171,6 +178,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["RS256"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -194,6 +202,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256", "extra"],
             credential_validity_period_max_days: 30,
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -211,6 +220,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             doctype: "org.iso.18013.5.1.mDL",
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 
@@ -234,6 +244,7 @@ describe("credentialConfigurationsSupportedSchema", () => {
             cryptographic_binding_methods_supported: ["cose_key"],
             credential_signing_alg_values_supported: ["ES256"],
             credential_validity_period_max_days: "30",
+            credential_refresh_web_journey_url: "https://example.com/refresh",
           },
         };
 

--- a/test/helpers/metadata/credentialConfigurationsSupportedSchema.ts
+++ b/test/helpers/metadata/credentialConfigurationsSupportedSchema.ts
@@ -34,6 +34,7 @@ export const credentialConfigurationsSupportedSchema = {
         "cryptographic_binding_methods_supported",
         "credential_signing_alg_values_supported",
         "credential_validity_period_max_days",
+        "credential_refresh_web_journey_url",
       ],
       if: {
         properties: { format: { const: "mso_mdoc" } },

--- a/test/helpers/metadata/isValidMetadata.ts
+++ b/test/helpers/metadata/isValidMetadata.ts
@@ -20,7 +20,7 @@ export interface CredentialConfiguration {
   cryptographic_binding_methods_supported: string[];
   credential_signing_alg_values_supported: string[];
   credential_validity_period_max_days: number;
-  credential_refresh_web_journey_url?: string;
+  credential_refresh_web_journey_url: string;
   doctype?: string;
   credential_definition?: {
     type: string[];


### PR DESCRIPTION
## Proposed changes

### What changed
Made credential_refresh_web_journey_url mandatory.

### Why did it change
To align with the Tech Docs which are currently referencing the credential_refresh_web_journey_url field as mandatory. 

### Issue tracking
- [DCMAW-18091](https://govukverify.atlassian.net/browse/DCMAW-18091)

## Testing
Tested it locally:
<img width="595" height="386" alt="Screenshot 2026-04-28 at 13 24 01" src="https://github.com/user-attachments/assets/24685203-997a-41e5-9135-e9b70e2b684c" />

## Checklist

- [x] Changes are backwards compatible
- [x] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated


[DCMAW-18091]: https://govukverify.atlassian.net/browse/DCMAW-18091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ