### PR TITLE
ci: remove sonar bugs, refactor workflows to use reusable SonarQube scan and harden permissions

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -5,9 +5,15 @@ on:
     - cron: "0 0 * * 1-5"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-sonarqube-scan:
     name: Run SonarQube Scan
+    permissions:
+      contents: read
     uses: ./.github/workflows/sonarqube.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,10 +2,11 @@ name: Pull Request Checks
 
 on:
   pull_request:
-    - opened
-    - reopened
-    - ready_for_review
-    - synchronize
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
   workflow_dispatch:
     inputs:
       gitRef:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,6 +25,12 @@ jobs:
           command: check
           args: --from-latest-tag
 
+  run-sonarqube-scan:
+    name: Run SonarQube Scan
+    uses: ./.github/workflows/sonarqube.yml
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   build-lint-and-test:
     name: Build, lint and test
     runs-on: ubuntu-24.04
@@ -42,11 +48,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Build source code
-        run: npm run build
-
       - name: Run the linter
         run: npm run lint
 
-      - name: Run unit tests
-        run: npm run test:unit
+      - name: Build source code
+        run: npm run build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,7 +41,7 @@ jobs:
     name: Run SonarQube Scan
     uses: ./.github/workflows/sonarqube.yml
     permissions:
-      content: read
+      contents: read
     with:
       gitRef: ${{ inputs.gitRef || github.event.pull_request.head.sha }}
     secrets:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,10 @@ name: Pull Request
 
 on:
   pull_request:
+    - opened
+    - reopened
+    - ready_for_review
+    - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +15,8 @@ jobs:
   check-conventional-commits:
     name: Check conventional commits
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -28,12 +34,17 @@ jobs:
   run-sonarqube-scan:
     name: Run SonarQube Scan
     uses: ./.github/workflows/sonarqube.yml
+    permissions:
+      content: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   build-lint-and-test:
     name: Build, lint and test
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Pull Request
+name: Pull Request Checks
 
 on:
   pull_request:
@@ -64,6 +64,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,12 @@ on:
     - reopened
     - ready_for_review
     - synchronize
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: Branch name or commit SHA
+        required: false
+        default: main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -23,7 +29,7 @@ jobs:
         with:
           fetch-depth: 0
           # Pick the PR HEAD instead of the merge commit
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.gitRef || github.event.pull_request.head.sha }}
 
       - name: Verify conventional commit standards
         uses: cocogitto/cocogitto-action@52d0023b4396897f1815648e553db2ab8d782f3a # v4.2.0
@@ -36,6 +42,8 @@ jobs:
     uses: ./.github/workflows/sonarqube.yml
     permissions:
       content: read
+    with:
+      gitRef: ${{ inputs.gitRef || github.event.pull_request.head.sha }}
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -50,6 +58,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.gitRef || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -4,9 +4,15 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-sonarqube-scan:
     name: Run SonarQube Scan
     uses: ./.github/workflows/sonarqube.yml
+    permissions:
+      contents: read
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/push-to-main.yml
+++ b/.github/workflows/push-to-main.yml
@@ -1,9 +1,8 @@
-name: Nightly Quality Analysis & Docker Image Vulnerability Scan
-
+name: Push to main
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 jobs:
   run-sonarqube-scan:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
+          cache: npm
 
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,9 +1,10 @@
 name: SonarQube Analysis
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_call:
+    secrets:
+      SONAR_TOKEN:
+        required: true
+
 jobs:
   run-code-quality-and-security-analysis:
     name: Run code quality and security analysis

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,6 +1,12 @@
 name: SonarQube Analysis
 on:
   workflow_call:
+    inputs:
+      gitRef:
+        description: Branch name or commit SHA
+        required: false
+        default: main
+        type: string
     secrets:
       SONAR_TOKEN:
         required: true
@@ -17,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ inputs.gitRef }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -10,6 +10,8 @@ jobs:
     name: Run code quality and security analysis
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Check out repository code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY src ./src
 COPY test ./test
 COPY .nvmrc .npmrc jest.config.ts tsconfig.json package.json package-lock.json run-server-and-tests.sh run-server.sh run-tests.sh ./
 RUN mkdir -p /results && \
-    npm install && \
+    npm ci && \
     npm run build
 EXPOSE 3001
 ENV PORT=3001

--- a/test/helpers/credential/mdoc/validateIssuerAuth.ts
+++ b/test/helpers/credential/mdoc/validateIssuerAuth.ts
@@ -275,14 +275,16 @@ async function validateDeviceKey(
       "INVALID_DEVICE_KEY",
     );
   }
+  const x = deviceKey.get(COSE_KEY_PARAMETERS.EC2_X);
+  const y = deviceKey.get(COSE_KEY_PARAMETERS.EC2_Y);
 
-  if (!(deviceKey.get(COSE_KEY_PARAMETERS.EC2_X) instanceof Uint8Array)) {
+  if (!(x instanceof Uint8Array)) {
     throw new MDLValidationError(
       "DeviceKey x-coordinate (-2) must be a Uint8Array",
       "INVALID_DEVICE_KEY",
     );
   }
-  if (!(deviceKey.get(COSE_KEY_PARAMETERS.EC2_Y) instanceof Uint8Array)) {
+  if (!(y instanceof Uint8Array)) {
     throw new MDLValidationError(
       "DeviceKey y-coordinate (-3) must be a Uint8Array",
       "INVALID_DEVICE_KEY",
@@ -293,8 +295,8 @@ async function validateDeviceKey(
     const jwk = {
       kty: "EC",
       crv: "P-256",
-      x: Buffer.from(deviceKey.get(-2) as Uint8Array).toString("base64url"),
-      y: Buffer.from(deviceKey.get(-3) as Uint8Array).toString("base64url"),
+      x: Buffer.from(x).toString("base64url"),
+      y: Buffer.from(y).toString("base64url"),
     };
 
     await crypto.subtle.importKey(


### PR DESCRIPTION
## Proposed changes

### What changed

<!-- Describe the changes made -->

- sonarqube.yml — converted to a reusable workflow_call with a gitRef input, replacing direct push/PR triggers. Added permissions: contents: read and cache: npm.
- nightly-build.yml — replaced inline SonarQube steps with a call to sonarqube.yml. Added concurrency group.
- push-to-main.yml — new workflow replacing the push trigger removed from sonarqube.yml. Calls sonarqube.yml on merges to main.
- pull-request.yml — added explicit PR event types, workflow_dispatch with a gitRef input for manual runs, permissions: contents: read on all jobs, timeout-minutes: 15, cache: npm, and a SonarQube 
- scan job passing gitRef through to sonarqube.yml.
- release.yml — added timeout-minutes: 15.
- Dockerfile — replaced npm install with npm ci.
- validateIssuerAuth.ts — extracted deviceKey.get() calls into variables so TypeScript narrows the types correctly, removing Sonar-flagged unnecessary casts.

### Why did it change

<!-- Describe the reason these changes were made -->
- To fix sonar issues
- To ensure that the nightly build updates the test coverage

### Issue tracking

<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-XXXX](https://govukverify.atlassian.net/browse/DCMAW-XXX)

## Testing

<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist

- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [ ] Documentation (e.g. README.md) has been updated

## Related Pull Requests

<!-- List any related pull requests that need to be reviewed or merged alongside this one -->
