### PR TITLE
docs: add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # GOV.UK Wallet credential issuer test harness
 
+> **⚠️ This repository has been moved**
+>
+> This project is now part of a monorepo and can be found at:
+> https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer
+>
+> This repository was archived in May 2026.
+
 ## Overview
 
 The GOV.UK Wallet test harness lets you validate your credential issuance implementation without using the GOV.UK One Login app.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 > https://github.com/govuk-one-login/mobile-wallet-example-credential-issuer
 >
 > This repository was archived in May 2026.
+>
+> No further updates, bug fixes, or security patches will be provided for this repository.
 
 ## Overview
 


### PR DESCRIPTION
## Proposed changes
### What changed

Add notice to README indicating that this repository has been moved to the mobile-wallet-example-credential-issuer monorepo and was archived in May 2026.

This ensures users are directed to the new location of the code.

### Why did it change
As above.

### Issue tracking
<!-- List any related Jira tickets -->
<!-- List any related ADRs or RFCs -->

- [DCMAW-19913](https://govukverify.atlassian.net/browse/DCMAW-19913)

## Testing
<!-- Give an overview of how the changes were tested and attach evidence (if applicable) -->

## Checklist
- [ ] Changes are backwards compatible
- [ ] There are unit tests for any new logic implemented
- [x] Documentation (e.g. README.md) has been updated

## Related Pull Requests
<!-- List any related pull requests that need to be reviewed or merged alongside this one -->

[DCMAW-19913]: https://govukverify.atlassian.net/browse/DCMAW-19913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ